### PR TITLE
Add HELLO-based neighbor detection and energy-aware AODV simulation modules

### DIFF
--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import copy
+import random
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+import numpy as np
+import simpy
+
+
+@dataclass
+class Message:
+    """Message réseau : RREQ / RREP / DATA / HELLO / RERR."""
+    type: str
+    src_id: int
+    src_seq: int
+    dest_id: int
+    dest_seq: int = -1
+    weight: float = 0.0
+    prev_hop: int = -1
+
+
+@dataclass
+class NetworkStats:
+    """Compteurs de métriques réseau."""
+    messages_forwarded: int = 0
+    messages_initiated: int = 0
+    messages_sent: int = 0
+    messages_received: int = 0
+    rreq_sent: int = 0
+    rreq_forwarded: int = 0
+    rrep_sent: int = 0
+    energy_consumed: float = 0.0
+    dead_nodes: int = 0
+    seuiled: int = 0
+    hello_sent: int = 0
+    rerr_sent: int = 0
+    first_node_death_time: float | None = None
+    ten_percent_death_time: float | None = None
+    fifty_percent_death_time: float | None = None
+    death_times: list[float] = field(default_factory=list)
+
+
+class Network:
+    def __init__(self, config, reg_aodv: bool, protocol):
+        self.cfg = config
+        self.protocol = protocol
+        self.reg_aodv = reg_aodv  # True si on utilise AODV et false sinon
+        self.env = simpy.Environment()
+        self.G: Dict[int, "Node"] = {}
+        self.stop = False  # passé à True quand on veut que la simulation s'arrête
+        self.stats = NetworkStats()  # inclut les stats de mort des noeuds
+
+        self.data_log = {}  # (src_id, data_seq) -> {'t_init','t_send','t_recv'}
+        self.data_init_times = []
+        self.data_send_times = []
+
+        self.last_hello = {}  # (node_id, neighbor_id) -> dernière date HELLO reçue
+        self.hello_interval = 1.0
+        self.hello_timeout = 3.0
+        self.env.process(self._hello_loop())
+        self.env.process(self._hello_watchdog())
+
+    def add_node(self, node):
+        self.G[node.id] = node
+
+    def get_distance(self, n1, n2) -> float:
+        return ((n2.pos[0] - n1.pos[0]) ** 2 + (n2.pos[1] - n1.pos[1]) ** 2) ** 0.5
+
+    def update_battery(self, node, msg_type: str) -> bool:
+        consommation = node.initial_battery * (self.cfg.conso[0] if msg_type[:2] == "RR" else self.cfg.conso[1])
+        node.battery = max(0.0, node.battery - consommation)
+        self.stats.energy_consumed += consommation
+        if node.battery == 0 and node.alive:
+            self.env.process(self._kill_node(node))
+        return node.battery > 0
+
+    def _kill_node(self, node):
+        yield self.env.timeout(0)
+        node.alive = False
+        self.stats.dead_nodes += 1
+        self.stats.death_times.append(self.env.now)
+
+        if self.stats.first_node_death_time is None:
+            self.stats.first_node_death_time = self.env.now
+        if self.stats.ten_percent_death_time is None and self.stats.dead_nodes >= self.cfg.nb_nodes * 0.1:
+            self.stats.ten_percent_death_time = self.env.now
+        if self.stats.fifty_percent_death_time is None and self.stats.dead_nodes >= self.cfg.nb_nodes * 0.5:
+            self.stats.fifty_percent_death_time = self.env.now
+            self.stop = True
+
+    def calculate_weight(self, n1, n2) -> float:
+        if self.reg_aodv:
+            return 1.0
+        bat = max(n2.battery, 0.1)
+        dist_norm = self.get_distance(n1, n2) / n1.max_dist
+        bat_norm = 1 - (bat / n1.initial_battery)
+        weight = (self.cfg.coeff_dist_weight * dist_norm) + (self.cfg.coeff_bat_weight * bat_norm)
+
+        threshold = n2.initial_battery * self.cfg.seuil_coeff
+        if bat < threshold:
+            self.stats.seuiled += 1
+            gap = (threshold - bat) / threshold
+            weight += min(1.0, gap)
+        return weight
+
+    def get_energy_stats(self) -> Tuple[float, float]:
+        alive_nodes = [node for node in self.G.values() if node.alive]
+        if not alive_nodes:
+            return 0.0, 0.0
+        energies = [node.battery for node in alive_nodes]
+        return float(np.mean(energies)), float(np.std(energies))
+
+    def broadcast_rreq(self, node, rreq):
+        for neighbor in self.G.values():
+            if neighbor.id == node.id or (not neighbor.alive) or self.get_distance(node, neighbor) > node.max_dist:
+                continue
+            yield self.env.timeout(random.uniform(0.01, 0.05))  # jitter aléatoire avant transmission
+            neighbor.pending.put(copy.deepcopy(rreq))
+            self.stats.rreq_forwarded += 1
+
+    def unicast_rrep(self, node, rrep):
+        next_hop = node.routing_table.get(rrep.dest_id, (None, 0, 0, 0))[0]
+        if next_hop is None:
+            return
+        next_node = self.G.get(next_hop)
+        if next_node is None or not next_node.alive:
+            return
+        dist = self.get_distance(node, next_node)
+        if dist <= node.max_dist and self.update_battery(node, "RREP"):
+            yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
+            next_node.pending.put(rrep)
+
+    def forward_data(self, node, data):
+        next_hop = node.routing_table.get(data.dest_id, (None, 0, 0, 0))[0]
+        data.prev_hop = node.id
+        if next_hop is None:
+            return
+        next_node = self.G.get(next_hop)
+        if next_node is None or not next_node.alive:
+            invalidated = node.invalidate_route_via(next_hop)
+            if invalidated:
+                self.env.process(self.broadcast_rerr(node, invalidated))
+            return
+        dist = self.get_distance(node, next_node)
+        if dist <= node.max_dist and self.update_battery(node, "DATA"):
+            self.stats.messages_forwarded += 1
+            yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
+            next_node.pending.put(data)
+        else:
+            invalidated = node.invalidate_route_via(next_hop)
+            if invalidated:
+                self.env.process(self.broadcast_rerr(node, invalidated))
+
+    def mark_neighbor_seen(self, node_id, neighbor_id):
+        self.last_hello[(node_id, neighbor_id)] = self.env.now
+
+    def _hello_loop(self):
+        while not self.stop:
+            for node in self.G.values():
+                if not node.alive:
+                    continue
+                hello = Message(type="HELLO", src_id=node.id, src_seq=node.seq_num, dest_id=-1, prev_hop=node.id)
+                for neighbor in self.G.values():
+                    if neighbor.id == node.id or (not neighbor.alive) or self.get_distance(node, neighbor) > node.max_dist:
+                        continue
+                    neighbor.pending.put(copy.deepcopy(hello))
+                    self.stats.hello_sent += 1
+            yield self.env.timeout(self.hello_interval)
+
+    def _hello_watchdog(self):
+        while not self.stop:
+            now = self.env.now
+            for node in self.G.values():
+                if not node.alive:
+                    continue
+                broken_neighbors = []
+                for dest, (next_hop, seq_num, weight, expiry) in list(node.routing_table.items()):
+                    last = self.last_hello.get((node.id, next_hop), 0)
+                    if (now - last) > self.hello_timeout:
+                        broken_neighbors.append(next_hop)
+                for broken in set(broken_neighbors):
+                    invalidated = node.invalidate_route_via(broken)
+                    if invalidated:
+                        self.env.process(self.broadcast_rerr(node, invalidated))
+            yield self.env.timeout(self.hello_interval)
+
+    def broadcast_rerr(self, node, invalidated_destinations):
+        if not invalidated_destinations:
+            return
+        for broken_dest in invalidated_destinations:
+            rerr = Message(type="RERR", src_id=node.id, src_seq=node.seq_num, dest_id=broken_dest, prev_hop=node.id)
+            for neighbor in self.G.values():
+                if neighbor.id == node.id or (not neighbor.alive) or self.get_distance(node, neighbor) > node.max_dist:
+                    continue
+                yield self.env.timeout(random.uniform(0.001, 0.003))
+                neighbor.pending.put(copy.deepcopy(rerr))
+                self.stats.rerr_sent += 1
+
+    def log_data_init(self, src_id, data_seq, t_init):
+        key = (src_id, data_seq)
+        self.data_log[key] = {"t_init": t_init, "t_send": None, "t_recv": None}
+        self.data_init_times.append((t_init, key))
+
+    def log_data_send(self, src_id, data_seq, t_send):
+        key = (src_id, data_seq)
+        entry = self.data_log.get(key)
+        if entry and entry["t_send"] is None:
+            entry["t_send"] = t_send
+            self.data_send_times.append((t_send, key))
+
+    def log_data_recv(self, src_id, data_seq, t_recv):
+        key = (src_id, data_seq)
+        entry = self.data_log.get(key)
+        if entry and entry["t_recv"] is None:
+            entry["t_recv"] = t_recv

--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+
+import simpy
+
+from network_hello import Message
+
+
+class Node:
+    def __init__(self, node_id, pos, initial_battery, max_dist, network):
+        self.id = node_id  # id du noeud
+        self.pos = pos  # position (x,y) du noeud
+        self.initial_battery = initial_battery
+        self.battery = initial_battery  # batterie du noeud
+        self.max_dist = max_dist  # distance max d'émission / portée du noeud
+        self.network = network
+
+        self.routing_table = {}  # dest : {next_hop,seq_num,weight,expiry}
+        self.seq_num = 0
+        self.data_seq = 0
+
+        self.alive = True  # True si le noeud est vivant False si il est mort
+        self.pending = simpy.Store(network.env)  # requêtes en attente
+        self.seen = {}
+        self.collected_rreqs = {}
+        self.to_be_sent = defaultdict(list)
+
+        self.network.env.process(self.process_messages())
+
+    def process_messages(self):
+        while self.alive:
+            msg = yield self.pending.get()  # On bloque le process jusqu'à avoir un nouveau message
+            yield self.network.env.timeout(random.uniform(0.001, 0.005))  # délai de processing
+            if msg.type == "RREQ":
+                self.handle_rreq(msg)
+            elif msg.type == "RREP":
+                self.handle_rrep(msg)
+            elif msg.type == "DATA":
+                self.handle_data(msg)
+            elif msg.type == "HELLO":
+                self.handle_hello(msg)
+            elif msg.type == "RERR":
+                self.handle_rerr(msg)
+
+    def init_rreq(self, dest_id):
+        self.seq_num += 1
+        self.network.stats.rreq_sent += 1
+        rreq = Message(
+            type="RREQ",
+            src_id=self.id,
+            src_seq=self.seq_num,
+            dest_id=dest_id,
+            dest_seq=self.routing_table.get(dest_id, (None, 0, 0, 0))[1],
+            prev_hop=self.id,
+            weight=0.0,
+        )
+        self.network.env.process(self.network.broadcast_rreq(self, rreq))
+
+    def handle_rreq(self, rreq):
+        prev_node = self.network.G[rreq.prev_hop]
+        rreq.weight += self.network.calculate_weight(prev_node, self)
+        if rreq.src_id == self.id:
+            return  # éviter que les RREQs soient renvoyés à la source
+
+        seen_key = (rreq.src_id, rreq.src_seq)
+        count, min_weight = self.seen.get(seen_key, (0, float("inf")))
+        if count > self.network.protocol.max_duplicates or rreq.weight * self.network.protocol.weight_seuil >= min_weight:
+            return
+        self.seen[seen_key] = (count + 1, rreq.weight)
+
+        if self.id == rreq.dest_id:  # Si on est la destination du RREQ
+            key = (rreq.src_id, rreq.src_seq)
+            if key not in self.collected_rreqs:
+                self.collected_rreqs[key] = []
+                self.network.env.process(self.collect_rreps(key))  # on commence la collecte des RREPs
+            self.collected_rreqs[key].append(rreq)
+            return
+
+        self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        rreq.prev_hop = self.id
+        self.network.env.process(self.network.broadcast_rreq(self, rreq))
+
+    def handle_rrep(self, rrep):
+        prev_node = self.network.G[rrep.prev_hop]
+        rrep.weight += self.network.calculate_weight(prev_node, self)
+        self.update_route(rrep.src_id, rrep.prev_hop, rrep.src_seq, rrep.weight)
+
+        if self.id == rrep.dest_id:
+            if rrep.src_id in self.to_be_sent:
+                for msg in self.to_be_sent[rrep.src_id]:
+                    self.network.env.process(self.network.forward_data(self, msg))
+                    self.network.stats.messages_sent += 1
+                    self.network.log_data_send(self.id, msg.src_seq, self.network.env.now)
+                del self.to_be_sent[rrep.src_id]
+            return
+
+        rrep.prev_hop = self.id
+        self.network.env.process(self.network.unicast_rrep(self, rrep))
+
+    def send_rrep(self, rreq):
+        self.seq_num += 1
+        self.network.stats.rrep_sent += 1
+        self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        rrep = Message(
+            type="RREP",
+            src_id=self.id,
+            src_seq=self.seq_num,
+            dest_id=rreq.src_id,
+            prev_hop=self.id,
+        )
+        self.network.env.process(self.network.unicast_rrep(self, rrep))
+
+    def update_route(self, dest, next_hop, seq_num, weight):
+        current = self.routing_table.get(dest, (None, -1, float("inf"), 0))
+        ttl = self.network.cfg.ttl
+        if (seq_num > current[1]) or (seq_num == current[1] and weight < current[2]):
+            self.routing_table[dest] = (next_hop, seq_num, weight, self.network.env.now + ttl)
+
+    def collect_rreps(self, key):
+        yield self.network.env.timeout(0.2)
+        # On attend pour que tous les RREQs arrivent à la dest
+        if key in self.collected_rreqs:
+            self.send_rrep(min(self.collected_rreqs[key], key=lambda r: r.weight))  # on envoie le meilleur
+
+    def handle_data(self, data):
+        if data.dest_id == self.id:
+            self.network.stats.messages_received += 1
+            self.network.log_data_recv(data.src_id, data.src_seq, self.network.env.now)
+        else:
+            self.network.env.process(self.network.forward_data(self, data))
+
+
+
+    def handle_hello(self, hello):
+        # Mémorise la dernière réception HELLO pour détecter les ruptures de lien
+        self.network.mark_neighbor_seen(self.id, hello.src_id)
+
+    def invalidate_route_via(self, broken_neighbor):
+        # Supprime toutes les routes qui passent par le voisin rompu
+        invalidated = []
+        for dest, (next_hop, seq_num, weight, expiry) in list(self.routing_table.items()):
+            if next_hop == broken_neighbor:
+                del self.routing_table[dest]
+                invalidated.append(dest)
+        return invalidated
+
+    def handle_rerr(self, rerr):
+        if rerr.dest_id in self.routing_table:
+            del self.routing_table[rerr.dest_id]
+            self.network.env.process(self.network.broadcast_rerr(self, [rerr.dest_id]))
+    def send_data(self, dest_id):
+        self.data_seq += 1
+        self.network.stats.messages_initiated += 1
+        msg = Message(type="DATA", src_id=self.id, src_seq=self.data_seq, dest_id=dest_id, prev_hop=self.id, weight=-1)
+        self.network.log_data_init(self.id, self.data_seq, self.network.env.now)
+
+        if dest_id in self.routing_table:
+            self.network.env.process(self.network.forward_data(self, msg))
+            self.network.stats.messages_sent += 1
+            self.network.log_data_send(self.id, self.data_seq, self.network.env.now)
+        else:
+            self.to_be_sent[dest_id].append(msg)
+            self.init_rreq(dest_id)

--- a/Codes/epure/simulation_hello.py
+++ b/Codes/epure/simulation_hello.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+
+from network_hello import Network
+from node_hello import Node
+
+from multiprocessing import Pool, cpu_count
+
+
+
+@dataclass(frozen=True)
+class SimConfig:
+    """Paramètres globaux de simulation."""
+    nb_nodes: int
+    area_size: int
+    max_dist: float
+    init_bat: float
+    conso: Tuple[float, float]
+    dt: float
+    ttl: int
+    seuil_coeff: float
+    coeff_dist_weight: float
+    coeff_bat_weight: float
+    coeff_dist_bat: float
+    duration: float
+    window_size: float = 100.0
+
+
+@dataclass(frozen=True)
+class ProtocolConfig:
+    """Paramètres du protocole (AODV / Energy Aware)."""
+    reg_aodv: bool
+    max_duplicates: int
+    weight_seuil: float
+
+    @classmethod
+    def from_mode(cls, reg_aodv: bool) -> "ProtocolConfig":
+        return cls(reg_aodv=reg_aodv, max_duplicates=1 if reg_aodv else 3, weight_seuil=1.0 if reg_aodv else 1.5)
+
+
+class Simulation:
+    def __init__(self, config: SimConfig, protocol: ProtocolConfig, node_positions: Dict[int, Tuple[float, float]], trace_file: str, traffic_seed: int):
+        self.cfg = config
+        self.protocol = protocol
+        self.traffic_seed = traffic_seed  # seed pour le générateur aléatoire de messages
+        self.time_points = []  # Abscisse pour plot les résultats au cours du temps
+        self.net = Network(config=config, reg_aodv=protocol.reg_aodv, protocol=protocol)
+
+        if node_positions is None:
+            raise ValueError("node_positions ne peut pas être None")
+
+        for node_id in range(self.cfg.nb_nodes):
+            node = Node(node_id=node_id, pos=node_positions[node_id], initial_battery=self.cfg.init_bat, max_dist=self.cfg.max_dist, network=self.net)
+            self.net.add_node(node)
+
+        self.net.env.process(self._bm_replay(trace_file))
+
+    def _random_communication(self):
+        rng = random.Random(self.traffic_seed)
+        while self.net.env.now <= self.cfg.duration:
+            src_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            dest_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            while dest_id == src_id:
+                dest_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            # on choisit deux noeuds différents
+            src_node = self.net.G[src_id]
+            if src_node.alive:
+                src_node.send_data(dest_id)  # on lance le tranfert de données
+            yield self.net.env.timeout(self.cfg.dt)  # petit délai pour pas flood
+
+    def _monitor(self):
+        while self.net.env.now <= self.cfg.duration:
+            self.time_points.append(self.net.env.now)  # points temporels pour ploter les données
+            yield self.net.env.timeout(2 * self.cfg.dt)  # ce qui donne tous les 2 messages envoyés
+
+    def _bm_replay(self, file_path):
+        traces = {}
+        with open(file_path, "r", encoding="utf-8") as f:
+            for nid, line in enumerate(f):
+                vals = [float(v) for v in line.split()]
+                # Format BonnMotion : t x y t x y ...
+                if vals and nid < self.cfg.nb_nodes:
+                    traces[nid] = list(zip(vals[0::3], vals[1::3], vals[2::3]))
+
+        indexes = {nid: 0 for nid in traces}
+        for nid, seq in traces.items():
+            if seq:
+                self.net.G[nid].pos = (seq[0][1], seq[0][2])
+
+        while self.net.env.now <= self.cfg.duration:
+            sim_t = self.net.env.now
+            for nid, seq in traces.items():
+                node = self.net.G.get(nid)
+                if node is None or not node.alive:
+                    continue
+                idx = indexes[nid]
+                while idx + 1 < len(seq) and sim_t >= seq[idx + 1][0]:
+                    idx += 1
+                indexes[nid] = idx
+
+                if idx + 1 < len(seq):
+                    t0, x0, y0 = seq[idx]
+                    t1, x1, y1 = seq[idx + 1]
+                    if t1 > t0 and sim_t >= t0:
+                        u = (sim_t - t0) / (t1 - t0)
+                        # Interpolation linéaire
+                        node.pos = (x0 + u * (x1 - x0), y0 + u * (y1 - y0))  # Mise à jour
+                elif seq:
+                    node.pos = (seq[-1][1], seq[-1][2])
+            yield self.net.env.timeout(self.cfg.dt)
+
+    def run(self):
+        self.net.env.process(self._random_communication())
+        self.net.env.process(self._monitor())
+        while not self.net.stop and self.net.env.now <= self.cfg.duration:
+            self.net.env.step()
+
+    def get_metrics(self):
+        final_avg_bat, final_std_bat = self.net.get_energy_stats()
+        s = self.net.stats
+        return {
+            "dead_nodes": s.dead_nodes,
+            "energy": s.energy_consumed,
+            "msg_recv": s.messages_received,
+            "msg_sent": s.messages_sent,
+            "rreq_sent": s.rreq_sent,
+            "duration": self.net.env.now,
+            "rrep_sent": s.rrep_sent,
+            "messages_forwarded": s.messages_forwarded,
+            "messages_initiated": s.messages_initiated,
+            "rreq_forwarded": s.rreq_forwarded,
+            "seuiled": s.seuiled,
+            "first_node_death": s.first_node_death_time,
+            "ten_percent_death": s.ten_percent_death_time,
+            "final_avg_bat": final_avg_bat,
+            "final_std_bat": final_std_bat,
+            "fifty_percent_death": s.fifty_percent_death_time,
+        }
+
+@dataclass(frozen=True)
+class BonnMotionConfig:
+    bm_exe: str
+    out_dir: str
+    scenario: str = "RandomWaypoint"
+    vmin: float = 0.5
+    vmax: float = 1.0
+    pause: float = 50.0
+    o: float = 0.0
+
+
+def generate_bonnmotion_traces(sim_conf: SimConfig, bm_conf: BonnMotionConfig):
+    import gzip
+    import os
+    import shutil
+    import subprocess
+
+    os.makedirs(bm_conf.out_dir, exist_ok=True)
+    movements_files = []
+
+    for n_simu in range(sim_conf.nb_nodes):
+        base = os.path.join(bm_conf.out_dir, f"{sim_conf.nb_nodes}rw{n_simu}")
+        cmd = [
+            bm_conf.bm_exe,
+            "-f", base,
+            bm_conf.scenario,
+            "-n", str(sim_conf.nb_nodes),
+            "-d", str(sim_conf.duration),
+            "-x", str(sim_conf.area_size),
+            "-y", str(sim_conf.area_size),
+            "-l", str(bm_conf.vmin),
+            "-h", str(bm_conf.vmax),
+            "-p", str(bm_conf.pause),
+            "-o", str(bm_conf.o),
+        ]
+        subprocess.run(cmd, check=True)
+
+        gz_path = base + ".movements.gz"
+        mov_path = base + ".movements"
+        if os.path.exists(gz_path):
+            with gzip.open(gz_path, "rb") as f_in, open(mov_path, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(gz_path)
+
+        params_path = base + ".params"
+        if os.path.exists(params_path):
+            os.remove(params_path)
+        movements_files.append(mov_path)
+
+    return movements_files
+
+
+def run_comparison_simulations(config: SimConfig, nb_runs: int, seed_base: int, trace_files):
+    reg_aodv_res, mod_aodv_res = [], []
+    for i in range(nb_runs):
+        seed_i = seed_base + i
+        random.seed(seed_i)
+        np.random.seed(seed_i)
+
+        positions = {
+            i_node: (
+                random.uniform(0, config.area_size),
+                random.uniform(0, config.area_size),
+            )
+            for i_node in range(config.nb_nodes)
+        }
+
+        for reg_aodv in [True, False]:
+            random.seed(seed_i)
+            np.random.seed(seed_i)
+            protocol = ProtocolConfig.from_mode(reg_aodv)
+            sim = Simulation(config=config, protocol=protocol, node_positions=positions, trace_file=trace_files[i], traffic_seed=seed_i)
+            sim.run()
+            (reg_aodv_res if reg_aodv else mod_aodv_res).append(sim.get_metrics())
+
+    return {"reg": reg_aodv_res, "mod": mod_aodv_res}
+
+
+def calc_avg_metrics(res):
+    if not res:
+        return {}
+    avg = {}
+    for key in res[0].keys():
+        values = [r[key] for r in res if r[key] is not None]
+        avg[key] = (sum(values) / len(values)) if values else None
+        avg[f"{key}_count"] = len(values)
+    return avg
+
+def _one_point(args):
+    config, nb_runs, seed_base, trace_files = args
+    res = run_comparison_simulations(config=config, nb_runs=nb_runs, seed_base=seed_base, trace_files=trace_files)
+    reg_avg = calc_avg_metrics(res["reg"])
+    mod_avg = calc_avg_metrics(res["mod"])
+    return config.nb_nodes, reg_avg, mod_avg
+
+
+def densite_parallel(sim_conf: SimConfig, bm_conf: BonnMotionConfig, nb_runs: int, pas: int, factor_min: float = 0.7, factor_max: float = 1.5):
+
+    n_min = (sim_conf.area_size / sim_conf.max_dist) ** 2 * np.pi
+    n_lo = max(2, int(round(factor_min * n_min)))
+    n_hi = max(n_lo + 1, int(round(factor_max * n_min)))
+    nb_nodes_list = list(range(n_lo, n_hi + 1, pas))
+
+    tasks = []
+    for n_nodes in nb_nodes_list:
+        sim_conf_n = dataclass.replace(sim_conf,nb_nodes=n_nodes) #Copie de la config 
+        trace_files = generate_bonnmotion_traces(sim_conf_n, bm_conf)
+        tasks.append((sim_conf_n, nb_runs, 12345, trace_files))
+
+    with Pool(processes=max(1, cpu_count() - 1)) as pool:
+        results = pool.map(_one_point, tasks)
+
+    results.sort(key=lambda t: t[0])
+    return results
+
+
+def plot_windowed_delivery_over_time(sim_reg, sim_mod, W=None):
+    import matplotlib.pyplot as plt
+
+    if W is None:
+        W = sim_reg.cfg.window_size
+
+    if hasattr(sim_reg, "window_ratio_gen") and hasattr(sim_mod, "window_ratio_gen"):
+        plt.figure()
+        plt.plot(sim_reg.time_points, sim_reg.window_ratio_gen, label="AODV classique (t_gen)")
+        plt.plot(sim_mod.time_points, sim_mod.window_ratio_gen, label="AODV modifié (t_gen)")
+        plt.xlabel("Temps")
+        plt.ylabel("Taux de délivrance (%)")
+        plt.title(f"Taux glissant basé sur t_gen (fenêtre={W})")
+        plt.legend()
+        plt.show()
+
+    if hasattr(sim_reg, "window_ratio_send") and hasattr(sim_mod, "window_ratio_send"):
+        plt.figure()
+        plt.plot(sim_reg.time_points, sim_reg.window_ratio_send, label="AODV classique (t_send)")
+        plt.plot(sim_mod.time_points, sim_mod.window_ratio_send, label="AODV modifié (t_send)")
+        plt.xlabel("Temps")
+        plt.ylabel("Taux de délivrance (%)")
+        plt.title(f"Taux glissant basé sur t_send (fenêtre={W})")
+        plt.legend()
+        plt.show()


### PR DESCRIPTION
### Motivation
- Introduce a simulation stack that extends AODV with HELLO-based neighbor liveness detection and energy-aware routing decisions.
- Provide a reusable simulation harness that can replay BonnMotion traces, generate traffic, and compare classic vs modified AODV modes.

### Description
- Add `network_hello.py` implementing `Network`, `Message`, and `NetworkStats` with HELLO emission (`_hello_loop`), HELLO watchdog (`_hello_watchdog`), energy accounting (`update_battery`/`_kill_node`), routing weight calculation (`calculate_weight`), RREQ/RREP/RERR broadcast/unicast and data forwarding (`broadcast_rreq`, `unicast_rrep`, `forward_data`), and data logging helpers (`log_data_init/send/recv`).
- Add `node_hello.py` implementing `Node` behavior including message processing loop (`process_messages`), RREQ initiation (`init_rreq`), RREQ/RREP/DATA/RERR/HELLO handlers, route updates and invalidation, deferred sends via `to_be_sent`, and RREP collection (`collect_rreps`).
- Add `simulation_hello.py` implementing `Simulation` and config dataclasses (`SimConfig`, `ProtocolConfig`), BonnMotion trace conversion (`generate_bonnmotion_traces`), replay of movement traces (`_bm_replay`), random traffic generator (`_random_communication`), monitoring (`_monitor`), comparison runner (`run_comparison_simulations`), parallel density sweep helper (`densite_parallel`), and plotting utilities for windowed delivery rates.
- Provide support for running multiple runs, mode selection (`reg_aodv`), and metrics aggregation (`get_metrics` and `calc_avg_metrics`).

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04743876c48320ac90751aaec190fa)