### PR TITLE
Fix battery consumption scaling in epure hello simulation

### DIFF
--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -71,7 +71,9 @@ class Network:
         return ((n2.pos[0] - n1.pos[0]) ** 2 + (n2.pos[1] - n1.pos[1]) ** 2) ** 0.5
 
     def update_battery(self, node, msg_type: str) -> bool:
-        consommation = node.initial_battery * (self.cfg.conso[0] if msg_type[:2] == "RR" else self.cfg.conso[1])
+        # conso est exprimée en pourcentage de la batterie initiale par envoi
+        coeff = self.cfg.conso[0] if msg_type[:2] == "RR" else self.cfg.conso[1]
+        consommation = node.initial_battery * (coeff / 100.0)
         node.battery = max(0.0, node.battery - consommation)
         self.stats.energy_consumed += consommation
         if node.battery == 0 and node.alive:


### PR DESCRIPTION
### Motivation
- The `conso` parameter was previously treated as a direct multiplier of `initial_battery`, causing extremely large per-message drains and premature mass node death which made simulations stop very early.

### Description
- Adjusted `update_battery` in `Codes/epure/network_hello.py` to interpret `conso` entries as percentages of `initial_battery` per transmission by using `consommation = node.initial_battery * (coeff / 100.0)` and added a clarifying comment.
- Change is localized to the battery consumption computation and does not alter other protocol logic.

### Testing
- Verified syntax/bytecode compilation with `python -m py_compile Codes/epure/network_hello.py Codes/epure/node_hello.py Codes/epure/simulation_hello.py`, which completed successfully.
- No automated unit tests were present for this module; the change is limited and only affects battery drain scaling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a0c678dc832081cfce864ef9e5c0)