### PR TITLE
Ajoute consommation batterie à la réception des messages

### DIFF
--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -32,6 +32,8 @@ class Node:
     def process_messages(self):
         while self.alive:
             msg = yield self.pending.get()  # On bloque le process jusqu'à avoir un nouveau message
+            if not self.network.update_battery(self, f"RX_{msg.type}"):
+                break
             yield self.network.env.timeout(random.uniform(0.001, 0.005))  # délai de processing
             if msg.type == "RREQ":
                 self.handle_rreq(msg)


### PR DESCRIPTION
### Motivation
- Prendre en compte la consommation d'énergie lors de la réception des messages afin de simuler correctement l'épuisement des batteries des nœuds.

### Description
- Ajout d'un appel à `self.network.update_battery(self, f"RX_{msg.type}")` immédiatement après `msg = yield self.pending.get()` dans `Codes/epure/node_hello.py`, et arrêt de la boucle de traitement (`break`) si la batterie passe à 0.

### Testing
- Compilation vérifiée avec `python -m py_compile Codes/epure/node_hello.py Codes/epure/network_hello.py Codes/epure/simulation_hello.py` et sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c500775483208f5510c923de89b2)