### PR TITLE
Account for emission vs reception in battery updates and drain on message receipt

### DIFF
--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -70,9 +70,13 @@ class Network:
     def get_distance(self, n1, n2) -> float:
         return ((n2.pos[0] - n1.pos[0]) ** 2 + (n2.pos[1] - n1.pos[1]) ** 2) ** 0.5
 
-    def update_battery(self, node, msg_type: str) -> bool:
-        # conso est exprimée en pourcentage de la batterie initiale par envoi
-        coeff = self.cfg.conso[0] if msg_type[:2] == "RR" else self.cfg.conso[1]
+    def update_battery(self, node, msg_type: str, is_emission: bool = True) -> bool:
+        """Met à jour la batterie pour une émission ou une réception de message."""
+        control_msgs = {"RREQ", "RREP", "RERR", "HELLO"}
+        if is_emission:
+            coeff = self.cfg.conso[0] if msg_type in control_msgs else self.cfg.conso[1]
+        else:
+            coeff = self.cfg.conso[0] if msg_type in control_msgs else self.cfg.conso[1]
         consommation = node.initial_battery * (coeff / 100.0)
         node.battery = max(0.0, node.battery - consommation)
         self.stats.energy_consumed += consommation
@@ -132,7 +136,7 @@ class Network:
         if next_node is None or not next_node.alive:
             return
         dist = self.get_distance(node, next_node)
-        if dist <= node.max_dist and self.update_battery(node, "RREP"):
+        if dist <= node.max_dist and self.update_battery(node, "RREP", is_emission=True):
             yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
             next_node.pending.put(rrep)
 
@@ -148,7 +152,7 @@ class Network:
                 self.env.process(self.broadcast_rerr(node, invalidated))
             return
         dist = self.get_distance(node, next_node)
-        if dist <= node.max_dist and self.update_battery(node, "DATA"):
+        if dist <= node.max_dist and self.update_battery(node, "DATA", is_emission=True):
             self.stats.messages_forwarded += 1
             yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
             next_node.pending.put(data)

--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -32,6 +32,8 @@ class Node:
     def process_messages(self):
         while self.alive:
             msg = yield self.pending.get()  # On bloque le process jusqu'à avoir un nouveau message
+            if not self.network.update_battery(self, msg.type, is_emission=False):
+                break
             yield self.network.env.timeout(random.uniform(0.001, 0.005))  # délai de processing
             if msg.type == "RREQ":
                 self.handle_rreq(msg)


### PR DESCRIPTION
### Motivation
- Make battery accounting explicit for both emissions and receptions so node energy is decremented consistently and nodes die when battery reaches zero.
- Ensure routing/data forwarding honors energy cost on transmission and that receiving a message can also consume battery and trigger death.

### Description
- Changed `update_battery` signature to `update_battery(node, msg_type: str, is_emission: bool = True)` and added a docstring describing emission/reception behavior.
- Replaced the old control-message detection using `msg_type[:2]` with an explicit `control_msgs` set containing `"RREQ"`, `"RREP"`, `"RERR"`, and `"HELLO"` to determine consumption coefficients.
- Updated callers to pass the emission flag where appropriate: `unicast_rrep` and `forward_data` now call `update_battery(..., is_emission=True)` before transmitting, and `Node.process_messages` calls `update_battery(..., is_emission=False)` on receipt and breaks the processing loop if the node dies.
- Kept the energy bookkeeping and node death handling in `update_battery`, including triggering `_kill_node` and updating `NetworkStats` when battery hits zero.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c500775483208f5510c923de89b2)