### PR TITLE
Parallelize per-run loop in simulation_hello comparison runner

### DIFF
--- a/Codes/epure/simulation_hello.py
+++ b/Codes/epure/simulation_hello.py
@@ -197,31 +197,47 @@ def generate_bonnmotion_traces(sim_conf: SimConfig, bm_conf: BonnMotionConfig, n
     return movements_files
 
 
+
+
+def _run_single_mode(args):
+    config, protocol, positions, trace_file, seed_i = args
+    random.seed(seed_i)
+    np.random.seed(seed_i)
+    sim = Simulation(config=config, protocol=protocol, node_positions=positions, trace_file=trace_file, traffic_seed=seed_i)
+    sim.run()
+    return sim.get_metrics()
+
+
+def _run_single_comparison(args):
+    config, seed_i, trace_file = args
+    random.seed(seed_i)
+    np.random.seed(seed_i)
+
+    positions = {
+        i_node: (
+            random.uniform(0, config.area_size),
+            random.uniform(0, config.area_size),
+        )
+        for i_node in range(config.nb_nodes)
+    }
+
+    reg_protocol = ProtocolConfig.from_mode(True)
+    mod_protocol = ProtocolConfig.from_mode(False)
+
+    reg_metrics = _run_single_mode((config, reg_protocol, positions, trace_file, seed_i))
+    mod_metrics = _run_single_mode((config, mod_protocol, positions, trace_file, seed_i))
+    return reg_metrics, mod_metrics
+
 def run_comparison_simulations(config: SimConfig, nb_runs: int, seed_base: int, trace_files):
     print(f"Simulations a {config.nb_nodes} noeuds débutées")
-    reg_aodv_res, mod_aodv_res = [], []
-    for i in range(nb_runs):
-        print(f"run {i+1} débuté")
-        seed_i = seed_base + i
-        random.seed(seed_i)
-        np.random.seed(seed_i)
 
-        positions = {
-            i_node: (
-                random.uniform(0, config.area_size),
-                random.uniform(0, config.area_size),
-            )
-            for i_node in range(config.nb_nodes)
-        }
+    tasks = [(config, seed_base + i, trace_files[i]) for i in range(nb_runs)]
+    with Pool(processes=max(1, cpu_count() - 1)) as pool:
+        run_results = pool.map(_run_single_comparison, tasks)
 
-        for reg_aodv in [True, False]:
-            random.seed(seed_i)
-            np.random.seed(seed_i)
-            protocol = ProtocolConfig.from_mode(reg_aodv)
-            sim = Simulation(config=config, protocol=protocol, node_positions=positions, trace_file=trace_files[i], traffic_seed=seed_i)
-            sim.run()
-            (reg_aodv_res if reg_aodv else mod_aodv_res).append(sim.get_metrics())
-    
+    reg_aodv_res = [reg_metrics for reg_metrics, _ in run_results]
+    mod_aodv_res = [mod_metrics for _, mod_metrics in run_results]
+
     print(f"Simulations a {config.nb_nodes} noeuds terminées\n")
     return {"reg": reg_aodv_res, "mod": mod_aodv_res}
 

--- a/Codes/epure/simulation_hello.py
+++ b/Codes/epure/simulation_hello.py
@@ -12,7 +12,7 @@ from matplotlib import pyplot as plt
 from network_hello import Network
 from node_hello import Node
 
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool, cpu_count, current_process
 
 
 
@@ -232,8 +232,14 @@ def run_comparison_simulations(config: SimConfig, nb_runs: int, seed_base: int, 
     print(f"Simulations a {config.nb_nodes} noeuds débutées")
 
     tasks = [(config, seed_base + i, trace_files[i]) for i in range(nb_runs)]
-    with Pool(processes=max(1, cpu_count() - 1)) as pool:
-        run_results = pool.map(_run_single_comparison, tasks)
+
+    # Sous Windows (spawn), un worker de Pool est daemon et ne peut pas créer de sous-processus.
+    # On garde donc la parallélisation des runs uniquement si on est dans le process principal.
+    if current_process().daemon:
+        run_results = [_run_single_comparison(task) for task in tasks]
+    else:
+        with Pool(processes=max(1, cpu_count() - 1)) as pool:
+            run_results = pool.map(_run_single_comparison, tasks)
 
     reg_aodv_res = [reg_metrics for reg_metrics, _ in run_results]
     mod_aodv_res = [mod_metrics for _, mod_metrics in run_results]


### PR DESCRIPTION
### Motivation
- Rendre la parallélisation profitable même lorsque la simulation ne balaie qu'une seule densité en déplaçant le parallélisme du niveau "densité" vers le niveau "run".

### Description
- Modifié `Codes/epure/simulation_hello.py` pour ajouter `_run_single_mode` qui exécute une simulation unique (initialisation des seeds, run, collecte des métriques).
- Ajouté `_run_single_comparison` qui génère une fois les positions par run seedée puis lance les deux modes de protocole sur les mêmes positions pour une comparaison stricte.
- Remplacé la boucle séquentielle interne dans `run_comparison_simulations` par une `Pool.map` sur des tâches `(config, seed_i, trace_file)` afin de paralléliser chaque run tout en conservant le contrat de sortie `{"reg": ..., "mod": ...}`.
- Aucune modification en dehors de `Codes/epure/simulation_hello.py` et comportement déterministe préservé via les seeds.

### Testing
- Exécuté `python -m py_compile Codes/epure/simulation_hello.py` et la compilation a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a086ae484188320aca2b5477773c201)