### PR TITLE
Add TTL to RREQs and implement adaptive RREQ retry/backoff with rreq_state tracking

### DIFF
--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -19,6 +19,7 @@ class Message:
     dest_seq: int = -1
     weight: float = 0.0
     prev_hop: int = -1
+    ttl: int = 0
 
 
 @dataclass

--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import random
 from collections import defaultdict
+import math
 
 import simpy
 
@@ -26,6 +27,7 @@ class Node:
         self.seen = {}
         self.collected_rreqs = {}
         self.to_be_sent = defaultdict(list)
+        self.rreq_state = {}  # dest_id -> {ttl, in_flight}
 
         self.network.env.process(self.process_messages())
 
@@ -47,6 +49,18 @@ class Node:
                 self.handle_rerr(msg)
 
     def init_rreq(self, dest_id):
+        state = self.rreq_state.get(dest_id)
+        if state and state.get("in_flight"):
+            return
+
+        ttl_max = max(2, int(self.network.cfg.ttl))
+        if state is None:
+            ttl = min(2, ttl_max)
+        else:
+            ttl = min(ttl_max, max(state["ttl"] + 2, int(math.ceil(state["ttl"] * 1.5))))
+
+        self.rreq_state[dest_id] = {"ttl": ttl, "in_flight": True}
+
         self.seq_num += 1
         self.network.stats.rreq_sent += 1
         rreq = Message(
@@ -57,10 +71,14 @@ class Node:
             dest_seq=self.routing_table.get(dest_id, (None, 0, 0, 0))[1],
             prev_hop=self.id,
             weight=0.0,
+            ttl=ttl,
         )
         self.network.env.process(self.network.broadcast_rreq(self, rreq))
+        self.network.env.process(self._retry_rreq_if_needed(dest_id, rreq.src_seq))
 
     def handle_rreq(self, rreq):
+        if rreq.ttl <= 0:
+            return
         prev_node = self.network.G[rreq.prev_hop]
 
         is_final_hop = (self.id == rreq.dest_id)
@@ -88,7 +106,11 @@ class Node:
             return
 
         self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        if rreq.ttl <= 1:
+            return
+
         rreq.prev_hop = self.id
+        rreq.ttl -= 1
         self.network.env.process(self.network.broadcast_rreq(self, rreq))
 
     def handle_rrep(self, rrep):
@@ -107,6 +129,7 @@ class Node:
         self.update_route(rrep.src_id, rrep.prev_hop, rrep.src_seq, rrep.weight)
 
         if self.id == rrep.dest_id:
+            self.rreq_state.pop(rrep.src_id, None)
             if rrep.src_id in self.to_be_sent:
                 for msg in self.to_be_sent[rrep.src_id]:
                     self.network.env.process(self.network.forward_data(self, msg))
@@ -182,3 +205,25 @@ class Node:
         else:
             self.to_be_sent[dest_id].append(msg)
             self.init_rreq(dest_id)
+    def _retry_rreq_if_needed(self, dest_id, src_seq):
+        yield self.network.env.timeout(0.6)
+
+        state = self.rreq_state.get(dest_id)
+        if not state or not state.get("in_flight"):
+            return
+
+        if dest_id in self.routing_table:
+            self.rreq_state.pop(dest_id, None)
+            return
+
+        if self.seq_num != src_seq:
+            state["in_flight"] = False
+            return
+
+        ttl_max = max(2, int(self.network.cfg.ttl))
+        if state["ttl"] >= ttl_max:
+            state["in_flight"] = False
+            return
+
+        state["in_flight"] = False
+        self.init_rreq(dest_id)


### PR DESCRIPTION
### Motivation
- Bound RREQ flooding and avoid unlimited propagation by adding a TTL field to route requests.
- Improve route discovery reliability and reduce duplicate RREQ storms by tracking RREQ attempts per destination and adaptively increasing TTL on retries.

### Description
- Add `ttl` field to `Message` and use it to drop/stop forwarding RREQs when TTL is exhausted in `handle_rreq` and decrement TTL before rebroadcast.
- Add `rreq_state` to `Node` to track per-destination `{ttl, in_flight}` and prevent concurrent in-flight RREQs.
- Update `init_rreq` to compute an initial/incremental TTL based on `network.cfg.ttl`, mark the RREQ as in-flight, and spawn a retry helper after sending the RREQ.
- Add `_retry_rreq_if_needed` helper that waits (`yield timeout(0.6)`), checks route/RREQ state, and reissues `init_rreq` with an increased TTL up to the configured maximum; also clear state on receiving an RREP and when appropriate.

### Testing
- Ran the project unit test suite with `pytest` and verified it completed successfully. 
- Executed a short simulation scenario that exercises RREQ initiation, TTL-limited forwarding and adaptive retries, and observed expected RREQ/RREP flows without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08718981f48320959be8d9d895c63c)