### PR TITLE
Introduce RREQ TTL, rate-limited RERRs, hello timing and weight tuning

### DIFF
--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -207,12 +207,16 @@ class Network:
         next_hop = node.routing_table.get(data.dest_id, (None, 0, 0, 0))[0]
         data.prev_hop = node.id
         if next_hop is None:
+            node.to_be_sent[data.dest_id].append(copy.deepcopy(data))
+            node.init_rreq(data.dest_id)
             return
         next_node = self.G.get(next_hop)
         if next_node is None or not next_node.alive:
             invalidated = node.invalidate_route_via(next_hop)
             if invalidated:
                 self.env.process(self.broadcast_rerr(node, invalidated))
+            node.to_be_sent[data.dest_id].append(copy.deepcopy(data))
+            node.init_rreq(data.dest_id)
             return
         dist = self.get_distance(node, next_node)
         if dist <= node.max_dist and self.update_battery(node, "DATA", is_emission=True):
@@ -223,6 +227,8 @@ class Network:
             invalidated = node.invalidate_route_via(next_hop)
             if invalidated:
                 self.env.process(self.broadcast_rerr(node, invalidated))
+            node.to_be_sent[data.dest_id].append(copy.deepcopy(data))
+            node.init_rreq(data.dest_id)
 
     def mark_neighbor_seen(self, node_id, neighbor_id):
         self.last_hello[(node_id, neighbor_id)] = self.env.now

--- a/Codes/epure/network_hello.py
+++ b/Codes/epure/network_hello.py
@@ -19,6 +19,7 @@ class Message:
     dest_seq: int = -1
     weight: float = 0.0
     prev_hop: int = -1
+    ttl: int = 0
 
 
 @dataclass
@@ -59,8 +60,10 @@ class Network:
         self.data_send_times = []
 
         self.last_hello = {}  # (node_id, neighbor_id) -> dernière date HELLO reçue
-        self.hello_interval = 1.0
-        self.hello_timeout = 3.0
+        self.hello_interval = max(1.0, config.dt * 4)
+        self.hello_timeout = max(6.0, self.hello_interval * 3)
+        self.hello_grace = self.hello_timeout
+        self.rerr_recent = {}  # dest_id -> last emit time
         self.env.process(self._hello_loop())
         self.env.process(self._hello_watchdog())
 
@@ -137,8 +140,8 @@ class Network:
         d_norm = d / n1.max_dist
 
         # Paramètres optimisables
-        x_min = 0.15      # saut trop court si d < 30 % de la portée
-        x_safe = 0.80     # saut risqué si d > 75 % de la portée
+        x_min = 0.30      # saut trop court si d < 30 % de la portée
+        x_safe = 0.75     # saut risqué si d > 75 % de la portée
 
         poids_distance = 0.0
 
@@ -169,7 +172,7 @@ class Network:
                 self.stats.seuiled += 1
                 # gap = (threshold - bat) / max(threshold, eps)
                 # poids_batterie += gap ** 2
-                poids_batterie += 2
+                poids_batterie += 0.5
 
         return self.cfg.coeff_dist_weight * poids_distance + self.cfg.coeff_bat_weight * poids_batterie
 
@@ -244,8 +247,14 @@ class Network:
                 if not node.alive:
                     continue
                 broken_neighbors = []
-                for (next_hop, _, _, _) in set(node.routing_table.values()):
-                    last = self.last_hello.get((node.id, next_hop), 0)
+                if now < self.hello_grace:
+                    continue
+                for (next_hop, _, _, expiry) in set(node.routing_table.values()):
+                    if now < expiry - self.cfg.ttl * 0.5:
+                        continue
+                    last = self.last_hello.get((node.id, next_hop))
+                    if last is None:
+                        continue
                     if (now - last) > self.hello_timeout:
                         broken_neighbors.append(next_hop)
                 for broken in set(broken_neighbors): # Pour pas avoir de doublons
@@ -257,6 +266,10 @@ class Network:
         if not invalidated_destinations:
             return
         for broken_dest in invalidated_destinations:
+            last_emit = self.rerr_recent.get(broken_dest)
+            if last_emit is not None and (self.env.now - last_emit) < self.hello_interval:
+                continue
+            self.rerr_recent[broken_dest] = self.env.now
             rerr = Message(type="RERR", src_id=node.id, src_seq=node.seq_num, dest_id=broken_dest, prev_hop=node.id)
             for neighbor in self.G.values():
                 if neighbor.id == node.id or (not neighbor.alive) or self.get_distance(node, neighbor) > node.max_dist:

--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -53,9 +53,10 @@ class Node:
                 self.handle_rerr(msg)
 
     def init_rreq(self, dest_id):
-        ttl_max = max(2, int(self.network.cfg.ttl))
+        ttl_max = max(self.network.cfg.rreq_ttl_start, int(self.network.cfg.rreq_ttl_max))
+        ttl_step = max(1, int(self.network.cfg.rreq_ttl_step))
         prev_ttl = self.rreq_ttl.get(dest_id, 0)
-        ttl = min(ttl_max, 2 if prev_ttl == 0 else prev_ttl + 2)
+        ttl = min(ttl_max, self.network.cfg.rreq_ttl_start if prev_ttl == 0 else prev_ttl + ttl_step)
         self.rreq_ttl[dest_id] = ttl
 
         self.seq_num += 1

--- a/Codes/epure/node_hello.py
+++ b/Codes/epure/node_hello.py
@@ -22,16 +22,22 @@ class Node:
         self.data_seq = 0
 
         self.alive = True  # True si le noeud est vivant False si il est mort
-        self.pending = simpy.Store(network.env)  # requêtes en attente
+        self.pending = simpy.Store(network.env, capacity=2000)  # borne anti-tempête
         self.seen = {}
         self.collected_rreqs = {}
         self.to_be_sent = defaultdict(list)
+        self.rreq_ttl = {}  # dest_id -> dernier TTL utilisé
 
         self.network.env.process(self.process_messages())
 
     def process_messages(self):
         while self.alive:
             msg = yield self.pending.get()  # On bloque le process jusqu'à avoir un nouveau message
+            if msg.type == "RREQ":
+                seen_key = (msg.src_id, msg.src_seq)
+                count, min_weight = self.seen.get(seen_key, (0, float("inf")))
+                if count >= self.network.protocol.max_duplicates and msg.weight >= min_weight:
+                    continue
             if not self.network.update_battery(self, msg.type, is_emission=False):
                 break
             yield self.network.env.timeout(random.uniform(0.001, 0.005))  # délai de processing
@@ -47,6 +53,11 @@ class Node:
                 self.handle_rerr(msg)
 
     def init_rreq(self, dest_id):
+        ttl_max = max(2, int(self.network.cfg.ttl))
+        prev_ttl = self.rreq_ttl.get(dest_id, 0)
+        ttl = min(ttl_max, 2 if prev_ttl == 0 else prev_ttl + 2)
+        self.rreq_ttl[dest_id] = ttl
+
         self.seq_num += 1
         self.network.stats.rreq_sent += 1
         rreq = Message(
@@ -57,10 +68,13 @@ class Node:
             dest_seq=self.routing_table.get(dest_id, (None, 0, 0, 0))[1],
             prev_hop=self.id,
             weight=0.0,
+            ttl=ttl,
         )
         self.network.env.process(self.network.broadcast_rreq(self, rreq))
 
     def handle_rreq(self, rreq):
+        if rreq.ttl <= 0:
+            return
         prev_node = self.network.G[rreq.prev_hop]
 
         is_final_hop = (self.id == rreq.dest_id)
@@ -88,7 +102,11 @@ class Node:
             return
 
         self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        if rreq.ttl <= 1:
+            return
+
         rreq.prev_hop = self.id
+        rreq.ttl -= 1
         self.network.env.process(self.network.broadcast_rreq(self, rreq))
 
     def handle_rrep(self, rrep):
@@ -107,6 +125,7 @@ class Node:
         self.update_route(rrep.src_id, rrep.prev_hop, rrep.src_seq, rrep.weight)
 
         if self.id == rrep.dest_id:
+            self.rreq_ttl.pop(rrep.src_id, None)
             if rrep.src_id in self.to_be_sent:
                 for msg in self.to_be_sent[rrep.src_id]:
                     self.network.env.process(self.network.forward_data(self, msg))

--- a/Codes/epure/simulation_hello.py
+++ b/Codes/epure/simulation_hello.py
@@ -42,7 +42,7 @@ class ProtocolConfig:
 
     @classmethod
     def from_mode(cls, reg_aodv: bool) -> "ProtocolConfig":
-        return cls(reg_aodv=reg_aodv, max_duplicates=1 if reg_aodv else 2, weight_seuil=1.0 if reg_aodv else 1.5)
+        return cls(reg_aodv=reg_aodv, max_duplicates=1, weight_seuil=1.0 if reg_aodv else 1.25)
 
 
 class Simulation:

--- a/Codes/epure/simulation_hello.py
+++ b/Codes/epure/simulation_hello.py
@@ -30,6 +30,9 @@ class SimConfig:
     coeff_dist_weight: float
     coeff_bat_weight: float
     duration: float
+    rreq_ttl_max: int = 8
+    rreq_ttl_start: int = 2
+    rreq_ttl_step: int = 2
     window_size: float = 100.0
 
 


### PR DESCRIPTION
### Motivation
- Reduce control storming and unnecessary battery drain by limiting RREQ flood propagation and RERR emission frequency.
- Make HELLO heartbeat timing adapt to simulation step and avoid premature route invalidation during startup.
- Adjust route selection penalties to balance hop distance and residual battery impact.

### Description
- Add a `ttl` field to `Message` and track per-destination RREQ TTLs in `Node` with `rreq_ttl`, implementing incrementing/limited TTL allocation in `Node.init_rreq` and decrement/check in `Node.handle_rreq` to stop excessive flooding.
- Add a capacity limit to node incoming store with `simpy.Store(..., capacity=2000)` and an early duplicate suppression check in `Node.process_messages` to prevent processing obvious redundant `RREQ`s.
- Make HELLO timers dynamic by setting `Network.hello_interval` to `max(1.0, config.dt * 4)` and `Network.hello_timeout` to `max(6.0, self.hello_interval * 3)`, add `hello_grace` to delay watchdog actions during startup, and change `_hello_watchdog` to use routing entry expiry heuristics instead of raw routing_table tuples.
- Rate-limit `RERR` emissions per destination with `Network.rerr_recent` so the same broken destination is not re-emitted within a single `hello_interval`.
- Tune route cost heuristic in `Network.calculate_weight` by changing `x_min`/`x_safe` thresholds and reducing the heavy battery under-threshold penalty from `2` to `0.5` to soften over-penalization of low-battery relays.
- Adjust protocol defaults in `ProtocolConfig.from_mode` to set `max_duplicates` to `1` and reduce `weight_seuil` for energy-aware mode to `1.25`.

### Testing
- Ran the project test suite with `pytest` (unit tests) and a smoke simulation run to exercise RREQ/RREP/HELLO/RERR flows; the tests completed successfully.
- Verified that basic scenarios produce fewer control floods and that HELLO watchdog no longer invalidates routes immediately at startup by running short-duration simulation traces (smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08718981f48320959be8d9d895c63c)