### PR TITLE
Add expiry-date routing variants for epure (node/network/simulation)

### DIFF
--- a/Codes/epure/network_expiry.py
+++ b/Codes/epure/network_expiry.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import copy
+import random
+from dataclasses import dataclass,field
+from typing import Dict, Tuple
+
+import numpy as np
+import simpy
+
+
+@dataclass
+class Message:
+    """Message réseau : RREQ / RREP / DATA."""
+    type: str
+    src_id: int
+    src_seq: int
+    dest_id: int
+    dest_seq: int = -1
+    weight: float = 0.0
+    prev_hop: int = -1
+    ttl: int = 0
+
+
+@dataclass
+class NetworkStats:
+    """Compteurs de métriques réseau."""
+    messages_forwarded: int = 0
+    messages_initiated: int = 0
+    messages_sent: int = 0
+    messages_received: int = 0
+    rreq_sent: int = 0
+    rreq_forwarded: int = 0
+    rrep_sent: int = 0
+    energy_consumed: float = 0.0
+    dead_nodes: int = 0
+    seuiled: int = 0
+    first_node_death_time: float | None = None
+    ten_percent_death_time: float | None = None
+    fifty_percent_death_time: float | None = None
+    death_times: list[float] = field(default_factory=list)
+
+
+
+
+class Network:
+    def __init__(self, config:"SimConfig", reg_aodv: bool, protocol):
+        self.cfg = config
+        self.protocol = protocol
+        self.reg_aodv = reg_aodv  # True si on utilise AODV et false sinon
+        self.env = simpy.Environment()
+        self.G: Dict[int, "Node"] = {}
+        self.stop = False  # passé à True quand on veut que la simulation s'arrête
+        self.stats = NetworkStats()
+
+        self.data_log = {}  # (src_id, data_seq) -> {'t_init','t_send','t_recv'}
+        self.data_init_times = []
+        self.data_send_times = []
+
+
+    def add_node(self, node):
+        self.G[node.id] = node
+
+    def get_distance(self, n1, n2) -> float:
+        return ((n2.pos[0] - n1.pos[0]) ** 2 + (n2.pos[1] - n1.pos[1]) ** 2) ** 0.5
+
+    def update_battery(self, node, msg_type: str, is_emission: bool = True) -> bool:
+        """Met à jour la batterie pour une émission ou une réception de message."""
+        control_msgs = {"RREQ", "RREP"}
+        if is_emission:
+            coeff = self.cfg.conso[1] if msg_type in control_msgs else self.cfg.conso[1]*self.cfg.conso[2]
+        else:
+            coeff = self.cfg.conso[0] if msg_type in control_msgs else self.cfg.conso[0]*self.cfg.conso[2]
+        consommation = node.initial_battery * (coeff / 100.0)
+        node.battery = max(0.0, node.battery - consommation)
+        self.stats.energy_consumed += consommation
+        if node.battery == 0 and node.alive:
+            self.env.process(self._kill_node(node))
+        return node.battery > 0
+
+    def _kill_node(self, node):
+        yield self.env.timeout(0)
+        node.alive = False
+        self.stats.dead_nodes += 1
+        self.stats.death_times.append(self.env.now)
+
+        if self.stats.first_node_death_time is None:
+            self.stats.first_node_death_time = self.env.now
+        if self.stats.ten_percent_death_time is None and self.stats.dead_nodes >= self.cfg.nb_nodes * 0.1:
+            self.stats.ten_percent_death_time = self.env.now
+        if self.stats.fifty_percent_death_time is None and self.stats.dead_nodes >= self.cfg.nb_nodes * 0.5:
+            self.stats.fifty_percent_death_time = self.env.now
+            self.stop = True
+
+    # def calculate_weight(self, n1, n2) -> float:
+    #     if self.reg_aodv:
+    #         return 1.0
+    #     bat = max(n2.battery, 0.1)
+    #     dist_norm = self.get_distance(n1, n2) / n1.max_dist
+    #     bat_norm = 1 - (bat / n1.initial_battery)
+    #     weight = (self.cfg.coeff_dist_weight * dist_norm) + (self.cfg.coeff_bat_weight * bat_norm)
+
+    #     threshold = n2.initial_battery * self.cfg.seuil_coeff
+    #     if bat < threshold:
+    #         self.stats.seuiled += 1
+    #         gap = (threshold - bat) / threshold
+    #         weight += min(1.0, gap)
+    #     return weight
+
+    def calculate_weight(self, n1, n2, is_final_hop: bool = False) -> float:
+        """
+        Poids d'un lien n1 -> n2 sous la forme :
+
+            poids = a * poids_distance + b * poids_batterie
+
+        avec :
+            a = self.cfg.coeff_dist_weight
+            b = self.cfg.coeff_bat_weight
+
+        Objectifs :
+        - pénaliser les sauts trop courts ;
+        - ne pas pénaliser le dernier saut uniquement parce qu'il est court ;
+        - pénaliser les sauts proches de la limite d'émission ;
+        - pénaliser les relais avec batterie faible.
+        """
+
+        if self.reg_aodv:
+            return 1.0  
+
+        d = self.get_distance(n1, n2)
+        d_norm = d / n1.max_dist
+
+        # Paramètres optimisables
+        x_min = 0.15      # saut trop court si d < 30 % de la portée
+        x_safe = 0.80     # saut risqué si d > 75 % de la portée
+
+        poids_distance = 0.0
+
+        # Pénalité des sauts trop courts.
+        # Elle n'est pas appliquée au dernier saut vers la destination.
+        if not is_final_hop and d_norm < x_min:
+            poids_distance += ((x_min - d_norm) / x_min) ** 2
+
+        # Pénalité des sauts proches de la limite radio.
+        # Elle reste active même pour le dernier saut.
+        if d_norm > x_safe:
+            poids_distance += ((d_norm - x_safe) / (1.0 - x_safe)) ** 2
+
+        poids_batterie = 0.0
+
+        # La batterie du dernier nœud n'est pas critique pour le relais,
+        # puisqu'il ne retransmet pas le paquet DATA ensuite.
+        if not is_final_hop:
+            bat = max(n2.battery, 0.0001)
+            bat_norm = 1.0 - (bat / n2.initial_battery)
+
+            # Pénalité progressive quand la batterie baisse
+            poids_batterie = bat_norm ** 2
+
+            # Sur-pénalité si le nœud est sous le seuil critique
+            threshold = n2.initial_battery * self.cfg.seuil_coeff
+            if bat < threshold:
+                self.stats.seuiled += 1
+                # gap = (threshold - bat) / max(threshold, eps)
+                # poids_batterie += gap ** 2
+                poids_batterie += 2
+
+        return self.cfg.coeff_dist_weight * poids_distance + self.cfg.coeff_bat_weight * poids_batterie
+
+    def get_energy_stats(self) -> Tuple[float, float]:
+        alive_nodes = [node for node in self.G.values() if node.alive]
+        if not alive_nodes:
+            return 0.0, 0.0
+        energies = [node.battery for node in alive_nodes]
+        return float(np.mean(energies)), float(np.std(energies))
+
+    def broadcast_rreq(self, node, rreq):
+        for neighbor in self.G.values():
+            if neighbor.id == node.id or (not neighbor.alive) or self.get_distance(node, neighbor) > node.max_dist:
+                continue
+            yield self.env.timeout(random.uniform(0.01, 0.05))  # jitter aléatoire avant transmission
+            neighbor.pending.put(copy.deepcopy(rreq))
+            self.stats.rreq_forwarded += 1
+
+    def unicast_rrep(self, node, rrep):
+        route = node.routing_table.get(rrep.dest_id)
+        if route is None or route[3] <= self.env.now:
+            node.routing_table.pop(rrep.dest_id, None)
+            return
+        next_hop = route[0]
+        next_node = self.G.get(next_hop)
+        if next_node is None or not next_node.alive:
+            return
+        dist = self.get_distance(node, next_node)
+        if dist <= node.max_dist and self.update_battery(node, "RREP", is_emission=True):
+            yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
+            next_node.pending.put(rrep)
+
+    def forward_data(self, node, data):
+        route = node.routing_table.get(data.dest_id)
+        data.prev_hop = node.id
+        if route is None or route[3] <= self.env.now:
+            node.routing_table.pop(data.dest_id, None)
+            return
+        next_hop = route[0]
+        next_node = self.G.get(next_hop)
+        if next_node is None or not next_node.alive:
+            node.routing_table.pop(data.dest_id, None)
+            return
+        dist = self.get_distance(node, next_node)
+        if dist <= node.max_dist and self.update_battery(node, "DATA", is_emission=True):
+            self.stats.messages_forwarded += 1
+            yield self.env.timeout(dist * 0.001 + random.uniform(0.01, 0.05))
+            next_node.pending.put(data)
+        else:
+            node.routing_table.pop(data.dest_id, None)
+
+    def log_data_init(self, src_id, data_seq, t_init):
+        key = (src_id, data_seq)
+        self.data_log[key] = {"t_init": t_init, "t_send": None, "t_recv": None}
+        self.data_init_times.append((t_init, key))
+
+    def log_data_send(self, src_id, data_seq, t_send):
+        key = (src_id, data_seq)
+        entry = self.data_log.get(key)
+        if entry and entry["t_send"] is None:
+            entry["t_send"] = t_send
+            self.data_send_times.append((t_send, key))
+
+    def log_data_recv(self, src_id, data_seq, t_recv):
+        key = (src_id, data_seq)
+        entry = self.data_log.get(key)
+        if entry and entry["t_recv"] is None:
+            entry["t_recv"] = t_recv

--- a/Codes/epure/node_expiry.py
+++ b/Codes/epure/node_expiry.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+import math
+
+import simpy
+
+from network_expiry import Message
+
+
+class Node:
+    def __init__(self, node_id, pos, initial_battery, max_dist, network):
+        self.id = node_id  # id du noeud
+        self.pos = pos  # position (x,y) du noeud
+        self.initial_battery = initial_battery
+        self.battery = initial_battery  # batterie du noeud
+        self.max_dist = max_dist  # distance max d'émission / portée du noeud
+        self.network = network
+
+        self.routing_table = {}  # dest : {next_hop,seq_num,weight,expiry}
+        self.seq_num = 0
+        self.data_seq = 0
+
+        self.alive = True  # True si le noeud est vivant False si il est mort
+        self.pending = simpy.Store(network.env)  # requêtes en attente
+        self.seen = {}
+        self.collected_rreqs = {}
+        self.to_be_sent = defaultdict(list)
+        self.rreq_state = {}  # dest_id -> {ttl, in_flight}
+
+        self.network.env.process(self.process_messages())
+
+    def process_messages(self):
+        while self.alive:
+            msg = yield self.pending.get()  # On bloque le process jusqu'à avoir un nouveau message
+            if not self.network.update_battery(self, msg.type, is_emission=False):
+                break
+            yield self.network.env.timeout(random.uniform(0.001, 0.005))  # délai de processing
+            if msg.type == "RREQ":
+                self.handle_rreq(msg)
+            elif msg.type == "RREP":
+                self.handle_rrep(msg)
+            elif msg.type == "DATA":
+                self.handle_data(msg)
+
+    def init_rreq(self, dest_id):
+        state = self.rreq_state.get(dest_id)
+        if state and state.get("in_flight"):
+            # Si on est déjà en train d'envoyer des RREQ à ce destinataire
+            return
+
+        ttl_max = max(2, int(self.network.cfg.ttl_max))
+        if state is None:
+            ttl = 2
+        else:
+            ttl = min(ttl_max, max(state["ttl"] + 2, int(math.ceil(state["ttl"] * 1.5))))
+
+        self.rreq_state[dest_id] = {"ttl": ttl, "in_flight": True}
+
+        self.seq_num += 1
+        self.network.stats.rreq_sent += 1
+        rreq = Message(
+            type="RREQ",
+            src_id=self.id,
+            src_seq=self.seq_num,
+            dest_id=dest_id,
+            dest_seq=self.routing_table.get(dest_id, (None, 0, 0, 0))[1],
+            prev_hop=self.id,
+            weight=0.0,
+            ttl=ttl,
+        )
+        self.network.env.process(self.network.broadcast_rreq(self, rreq))
+        self.network.env.process(self._retry_rreq_if_needed(dest_id, rreq.src_seq))
+
+    def handle_rreq(self, rreq):
+        if rreq.ttl <= 0:
+            return
+        prev_node = self.network.G[rreq.prev_hop]
+
+        is_final_hop = (self.id == rreq.dest_id)
+        rreq.weight += self.network.calculate_weight(
+            prev_node,
+            self,
+            is_final_hop=is_final_hop
+        )
+        
+        if rreq.src_id == self.id:
+            return  # éviter que les RREQs soient renvoyés à la source
+
+        seen_key = (rreq.src_id, rreq.src_seq)
+        count, min_weight = self.seen.get(seen_key, (0, float("inf")))
+        if count >= self.network.protocol.max_duplicates or rreq.weight * self.network.protocol.weight_seuil >= min_weight:
+            return
+        self.seen[seen_key] = (count + 1, rreq.weight)
+
+        if self.id == rreq.dest_id:  # Si on est la destination du RREQ
+            key = (rreq.src_id, rreq.src_seq)
+            if key not in self.collected_rreqs:
+                self.collected_rreqs[key] = []
+                self.network.env.process(self.collect_rreps(key))  # on commence la collecte des RREPs
+            self.collected_rreqs[key].append(rreq)
+            return
+
+        self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        if rreq.ttl <= 1:
+            return
+
+        rreq.prev_hop = self.id
+        rreq.ttl -= 1
+        self.network.env.process(self.network.broadcast_rreq(self, rreq))
+
+    def handle_rrep(self, rrep):
+        prev_node = self.network.G[rrep.prev_hop]
+
+        # Le coût doit être évalué dans le sens futur DATA :
+        # le nœud courant enverra vers prev_node pour atteindre rrep.src_id.
+        is_final_hop = (prev_node.id == rrep.src_id)
+
+        rrep.weight += self.network.calculate_weight(
+            self,
+            prev_node,
+            is_final_hop=is_final_hop
+        )
+
+        self.update_route(rrep.src_id, rrep.prev_hop, rrep.src_seq, rrep.weight)
+
+        if self.id == rrep.dest_id:
+            self.rreq_state.pop(rrep.src_id, None)
+            if rrep.src_id in self.to_be_sent:
+                for msg in self.to_be_sent[rrep.src_id]:
+                    self.network.env.process(self.network.forward_data(self, msg))
+                    self.network.stats.messages_sent += 1
+                    self.network.log_data_send(self.id, msg.src_seq, self.network.env.now)
+                del self.to_be_sent[rrep.src_id]
+            return
+
+        rrep.prev_hop = self.id
+        self.network.env.process(self.network.unicast_rrep(self, rrep))
+
+    def send_rrep(self, rreq):
+        self.seq_num += 1
+        self.network.stats.rrep_sent += 1
+        self.update_route(rreq.src_id, rreq.prev_hop, rreq.src_seq, rreq.weight)
+        rrep = Message(
+            type="RREP",
+            src_id=self.id,
+            src_seq=self.seq_num,
+            dest_id=rreq.src_id,
+            prev_hop=self.id,
+        )
+        self.network.env.process(self.network.unicast_rrep(self, rrep))
+
+    def update_route(self, dest, next_hop, seq_num, weight):
+        current = self.routing_table.get(dest, (None, -1, float("inf"), 0))
+        ttl = self.network.cfg.ttl_max
+        if (seq_num > current[1]) or (seq_num == current[1] and weight < current[2]):
+            self.routing_table[dest] = (next_hop, seq_num, weight, self.network.env.now + ttl)
+
+    def collect_rreps(self, key):
+        yield self.network.env.timeout(0.2)
+        # On attend pour que tous les RREQs arrivent à la dest
+        if key in self.collected_rreqs:
+            self.send_rrep(min(self.collected_rreqs[key], key=lambda r: r.weight))  # on envoie le meilleur
+
+    def handle_data(self, data):
+        if data.dest_id == self.id:
+            self.network.stats.messages_received += 1
+            self.network.log_data_recv(data.src_id, data.src_seq, self.network.env.now)
+        else:
+            self.network.env.process(self.network.forward_data(self, data))
+
+
+    def send_data(self, dest_id):
+        self.data_seq += 1
+        self.network.stats.messages_initiated += 1
+        msg = Message(type="DATA", src_id=self.id, src_seq=self.data_seq, dest_id=dest_id, prev_hop=self.id, weight=-1)
+        self.network.log_data_init(self.id, self.data_seq, self.network.env.now)
+
+        route = self.routing_table.get(dest_id)
+        if route and route[3] > self.network.env.now:
+            self.network.env.process(self.network.forward_data(self, msg))
+            self.network.stats.messages_sent += 1
+            self.network.log_data_send(self.id, self.data_seq, self.network.env.now)
+        else:
+            if route and route[3] <= self.network.env.now:
+                del self.routing_table[dest_id]
+            self.to_be_sent[dest_id].append(msg)
+            self.init_rreq(dest_id)
+    def _retry_rreq_if_needed(self, dest_id, src_seq):
+        yield self.network.env.timeout(2* 40*10**(-3)* 1.5*self.network.cfg.nb_nodes)
+
+        state = self.rreq_state.get(dest_id)
+        if not state or not state.get("in_flight"):
+            # Si on a fini de chercher une route
+            return
+
+        if dest_id in self.routing_table:
+            # Si on a fini de chercher une route et qu'elle est inscrite dans la table de routage
+            self.rreq_state.pop(dest_id, None)
+            return
+
+        if self.seq_num != src_seq:
+            state["in_flight"] = False
+            return
+
+        if state["ttl"] >= 7:
+            state["in_flight"] = False
+            return
+
+        state["in_flight"] = False
+        self.init_rreq(dest_id)

--- a/Codes/epure/simulation_expiry.py
+++ b/Codes/epure/simulation_expiry.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass,replace
+from typing import Dict, Tuple
+
+from time import time
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+from network_expiry import Network
+from node_expiry import Node
+
+from multiprocessing import Pool, cpu_count
+
+
+
+@dataclass(frozen=True)
+class SimConfig:
+    """Paramètres globaux de simulation."""
+    nb_nodes: int
+    area_size: int
+    max_dist: float
+    init_bat: float #En Joules
+    conso: Tuple[float, float, int] # RX, TX, TX(data)/TX(contrôle) = RX(data)/RX(contrôle)
+    dt: float
+    ttl_max: int
+    seuil_coeff: float
+    coeff_dist_weight: float
+    coeff_bat_weight: float
+    duration: float
+    window_size: float = 100.0
+
+
+@dataclass(frozen=True)
+class ProtocolConfig:
+    """Paramètres du protocole (AODV / Energy Aware)."""
+    reg_aodv: bool
+    max_duplicates: int
+    weight_seuil: float
+
+    @classmethod
+    def from_mode(cls, reg_aodv: bool) -> "ProtocolConfig":
+        return cls(reg_aodv=reg_aodv, max_duplicates=1 if reg_aodv else 2, weight_seuil=1.0 if reg_aodv else 1.25)
+
+
+class Simulation:
+    def __init__(self, config: SimConfig, protocol: ProtocolConfig, node_positions: Dict[int, Tuple[float, float]], trace_file: str, traffic_seed: int):
+        self.cfg = config
+        self.protocol = protocol
+        self.traffic_seed = traffic_seed  # seed pour le générateur aléatoire de messages
+        self.time_points = []  # Abscisse pour plot les résultats au cours du temps
+        self.net = Network(config=config, reg_aodv=protocol.reg_aodv, protocol=protocol)
+
+        if node_positions is None:
+            raise ValueError("node_positions ne peut pas être None")
+
+        for node_id in range(self.cfg.nb_nodes):
+            node = Node(node_id=node_id, pos=node_positions[node_id], initial_battery=self.cfg.init_bat, max_dist=self.cfg.max_dist, network=self.net)
+            self.net.add_node(node)
+
+        self.net.env.process(self._bm_replay(trace_file))
+
+    def _random_communication(self):
+        rng = random.Random(self.traffic_seed)
+        while self.net.env.now <= self.cfg.duration:
+            src_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            dest_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            while dest_id == src_id:
+                dest_id = rng.randint(0, self.cfg.nb_nodes - 1)
+            # on choisit deux noeuds différents
+            src_node = self.net.G[src_id]
+            if src_node.alive:
+                src_node.send_data(dest_id)  # on lance le tranfert de données
+            yield self.net.env.timeout(self.cfg.dt)  # petit délai pour pas flood
+
+    def _monitor(self):
+        while self.net.env.now <= self.cfg.duration:
+            self.time_points.append(self.net.env.now)  # points temporels pour ploter les données
+            yield self.net.env.timeout(2 * self.cfg.dt)  # ce qui donne tous les 2 messages envoyés
+
+    def _bm_replay(self, file_path):
+        traces = {}
+        with open(file_path, "r", encoding="utf-8") as f:
+            for nid, line in enumerate(f):
+                vals = [float(v) for v in line.split()]
+                # Format BonnMotion : t x y t x y ...
+                if vals and nid < self.cfg.nb_nodes:
+                    traces[nid] = list(zip(vals[0::3], vals[1::3], vals[2::3]))
+
+        indexes = {nid: 0 for nid in traces}
+        for nid, seq in traces.items():
+            if seq:
+                self.net.G[nid].pos = (seq[0][1], seq[0][2])
+
+        while self.net.env.now <= self.cfg.duration:
+            sim_t = self.net.env.now
+            for nid, seq in traces.items():
+                node = self.net.G.get(nid)
+                if node is None or not node.alive:
+                    continue
+                idx = indexes[nid]
+                while idx + 1 < len(seq) and sim_t >= seq[idx + 1][0]:
+                    idx += 1
+                indexes[nid] = idx
+
+                if idx + 1 < len(seq):
+                    t0, x0, y0 = seq[idx]
+                    t1, x1, y1 = seq[idx + 1]
+                    if t1 > t0 and sim_t >= t0:
+                        u = (sim_t - t0) / (t1 - t0)
+                        # Interpolation linéaire
+                        node.pos = (x0 + u * (x1 - x0), y0 + u * (y1 - y0))  # Mise à jour
+                elif seq:
+                    node.pos = (seq[-1][1], seq[-1][2])
+            yield self.net.env.timeout(self.cfg.dt)
+
+    def run(self):
+        self.net.env.process(self._random_communication())
+        self.net.env.process(self._monitor())
+        while not self.net.stop and self.net.env.now <= self.cfg.duration:
+            self.net.env.step()
+
+    def get_metrics(self):
+        final_avg_bat, final_std_bat = self.net.get_energy_stats()
+        s = self.net.stats
+        return {
+            "dead_nodes": s.dead_nodes,
+            "energy": s.energy_consumed,
+            "msg_recv": s.messages_received,
+            "msg_sent": s.messages_sent,
+            "rreq_sent": s.rreq_sent,
+            "duration": self.net.env.now,
+            "rrep_sent": s.rrep_sent,
+            "messages_forwarded": s.messages_forwarded,
+            "messages_initiated": s.messages_initiated,
+            "rreq_forwarded": s.rreq_forwarded,
+            "seuiled": s.seuiled,
+            "first_node_death": self.net.stats.first_node_death_time,
+            "ten_percent_death": self.net.stats.ten_percent_death_time,
+            "final_avg_bat": final_avg_bat,
+            "final_std_bat": final_std_bat,
+            "fifty_percent_death": self.net.stats.fifty_percent_death_time,
+        }
+
+@dataclass(frozen=True)
+class BonnMotionConfig:
+    bm_exe: str
+    out_dir: str
+    scenario: str = "RandomWaypoint"
+    vmin: int = 0
+    vmax: int = 1
+    pause: int = 50
+    o: int = 2
+
+
+def generate_bonnmotion_traces(sim_conf: SimConfig, bm_conf: BonnMotionConfig, nb_runs : int):
+    import gzip
+    import os
+    import shutil
+    import subprocess
+
+    os.makedirs(bm_conf.out_dir, exist_ok=True)
+    movements_files = []
+
+    for n_simu in range(nb_runs):
+        base = os.path.join(bm_conf.out_dir, f"{sim_conf.nb_nodes}rw{n_simu}")
+        cmd = " ".join([
+            bm_conf.bm_exe,
+            "-f", base,
+            bm_conf.scenario,
+            "-n", str(sim_conf.nb_nodes),
+            "-d", str(sim_conf.duration),
+            "-x", str(sim_conf.area_size),
+            "-y", str(sim_conf.area_size),
+            "-l", str(bm_conf.vmin),
+            "-h", str(bm_conf.vmax),
+            "-p", str(bm_conf.pause),
+            "-o", str(bm_conf.o),
+        ])
+        print(cmd)
+        subprocess.run(cmd, check=True)
+
+        gz_path = base + ".movements.gz"
+        mov_path = base + ".movements"
+        if os.path.exists(gz_path):
+            with gzip.open(gz_path, "rb") as f_in, open(mov_path, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(gz_path)
+
+        params_path = base + ".params"
+        if os.path.exists(params_path):
+            os.remove(params_path)
+        movements_files.append(mov_path)
+
+    return movements_files
+
+
+def run_comparison_simulations(config: SimConfig, nb_runs: int, seed_base: int, trace_files):
+    print(f"Simulations a {config.nb_nodes} noeuds débutées")
+    reg_aodv_res, mod_aodv_res = [], []
+    for i in range(nb_runs):
+        print(f"run {i+1} débuté")
+        seed_i = seed_base + i
+        random.seed(seed_i)
+        np.random.seed(seed_i)
+
+        positions = {
+            i_node: (
+                random.uniform(0, config.area_size),
+                random.uniform(0, config.area_size),
+            )
+            for i_node in range(config.nb_nodes)
+        }
+
+        for reg_aodv in [True, False]:
+            random.seed(seed_i)
+            np.random.seed(seed_i)
+            protocol = ProtocolConfig.from_mode(reg_aodv)
+            sim = Simulation(config=config, protocol=protocol, node_positions=positions, trace_file=trace_files[i], traffic_seed=seed_i)
+            sim.run()
+            (reg_aodv_res if reg_aodv else mod_aodv_res).append(sim.get_metrics())
+    
+    print(f"Simulations a {config.nb_nodes} noeuds terminées\n")
+    return {"reg": reg_aodv_res, "mod": mod_aodv_res}
+
+
+def calc_avg_metrics(res):
+    if not res:
+        return {}
+    avg = {}
+    for key in res[0].keys():
+        values = [r[key] for r in res if r[key] is not None]
+        avg[key] = (sum(values) / len(values)) if values else None
+        avg[f"{key}_count"] = len(values)
+    return avg
+
+def _one_point(args):
+    config, nb_runs, seed_base, trace_files = args
+    res = run_comparison_simulations(config=config, nb_runs=nb_runs, seed_base=seed_base, trace_files=trace_files)
+    reg_avg = calc_avg_metrics(res["reg"])
+    mod_avg = calc_avg_metrics(res["mod"])
+    return config.nb_nodes, reg_avg, mod_avg
+
+
+def densite_parallel(sim_conf: SimConfig, bm_conf: BonnMotionConfig, nb_runs: int, pas: int, deg_min: float = 0.7, deg_max: float = 1.5):
+    n_crit_moins_1 = (sim_conf.area_size / sim_conf.max_dist) ** 2 / np.pi
+    n_lo = max(2, int(round(deg_min * n_crit_moins_1))+1)
+    n_hi = max(n_lo + 1, int(round(deg_max * n_crit_moins_1))+1)
+    nb_nodes_list = list(range(n_lo, n_hi + 1, pas))
+
+    tasks = []
+    for n_nodes in nb_nodes_list:
+        sim_conf_n = replace(sim_conf,nb_nodes=n_nodes) #Copie de la config 
+        trace_files = generate_bonnmotion_traces(sim_conf_n, bm_conf,nb_runs)
+        tasks.append((sim_conf_n, nb_runs, int(time()), trace_files))
+
+    with Pool(processes=max(1, cpu_count() - 1)) as pool:
+        results = pool.map(_one_point, tasks)
+
+    results.sort(key=lambda t: t[0])
+    nb_nodes_array = []
+    reg_first_death, mod_first_death = [], []
+    reg_dr, mod_dr = [], []
+    reg_ten_percent_death, mod_ten_percent_death = [], []
+    reg_energy, mod_energy = [], []
+    reg_std, mod_std = [], []
+    reg_final_energy,mod_final_energy = [], []
+    reg_fifty_percent_death, mod_fifty_percent_death = [], []
+
+    for (N, reg_avg, mod_avg) in results:
+        nb_nodes_array.append(N)
+
+        reg_first_death.append(reg_avg.get("first_node_death", None))
+        mod_first_death.append(mod_avg.get("first_node_death", None))
+
+        reg_dr.append(reg_avg.get("msg_recv", 0) / max(1, reg_avg.get("messages_initiated",1)) * 100)
+        mod_dr.append(mod_avg.get("msg_recv", 0) / max(1, mod_avg.get("messages_initiated",1)) * 100)
+
+        reg_ten_percent_death.append(reg_avg.get("ten_percent_death", None))
+        mod_ten_percent_death.append(mod_avg.get("ten_percent_death", None))
+
+        reg_energy.append(reg_avg.get("energy", None))
+        mod_energy.append(mod_avg.get("energy", None))
+
+        reg_std.append(reg_avg.get("final_std_bat", None))
+        mod_std.append(mod_avg.get("final_std_bat", None))
+
+        reg_final_energy.append(reg_avg.get("final_avg_bat", None))
+        mod_final_energy.append(mod_avg.get("final_avg_bat", None))
+
+        reg_fifty_percent_death.append(reg_avg.get("fifty_percent_death", None))
+        mod_fifty_percent_death.append(mod_avg.get("fifty_percent_death", None))
+
+
+    # Affichage dans une seule fenêtre : sous-graphiques côte à côte
+    metrics_to_plot = [
+        ("Temps (first node death)", reg_first_death, mod_first_death),
+        ("Temps (10% death)", reg_ten_percent_death, mod_ten_percent_death),
+        ("Temps (50% death)", reg_fifty_percent_death, mod_fifty_percent_death),
+        ("Énergie résiduelle moyenne", reg_final_energy, mod_final_energy),
+        ("Énergie totale consommée", reg_energy, mod_energy),
+        ("Écart type énergie finale", reg_std, mod_std),
+        ("Delivery ratio (%)", reg_dr, mod_dr),
+    ]
+
+    n_cols = 4
+    n_rows = int(np.ceil(len(metrics_to_plot) / n_cols))
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5.5 * n_cols, 4.2 * n_rows), squeeze=False)
+    axes_flat = axes.flatten()
+
+    for ax, (ylabel, reg_vals, mod_vals) in zip(axes_flat, metrics_to_plot):
+        ax.plot(nb_nodes_array, reg_vals, marker='o', label="Regular")
+        ax.plot(nb_nodes_array, mod_vals, marker='s', label="Modified")
+        ax.set_xlabel("nb_nodes")
+        ax.set_ylabel(ylabel)
+        ax.grid(True, alpha=0.3)
+        ax.legend()
+
+    for ax in axes_flat[len(metrics_to_plot):]:
+        ax.axis("off")
+
+    fig.suptitle("Comparaison AODV régulier vs modifié selon la densité", fontsize=14)
+    fig.tight_layout(rect=[0, 0.02, 1, 0.96])
+    plt.show()
+    return results
+
+
+def plot_windowed_delivery_over_time(sim_reg, sim_mod, W=None):
+
+    if W is None:
+        W = sim_reg.cfg.window_size
+
+    if hasattr(sim_reg, "window_ratio_gen") and hasattr(sim_mod, "window_ratio_gen"):
+        plt.figure()
+        plt.plot(sim_reg.time_points, sim_reg.window_ratio_gen, label="AODV classique (t_gen)")
+        plt.plot(sim_mod.time_points, sim_mod.window_ratio_gen, label="AODV modifié (t_gen)")
+        plt.xlabel("Temps")
+        plt.ylabel("Taux de délivrance (%)")
+        plt.title(f"Taux glissant basé sur t_gen (fenêtre={W})")
+        plt.legend()
+        plt.show()
+
+    if hasattr(sim_reg, "window_ratio_send") and hasattr(sim_mod, "window_ratio_send"):
+        plt.figure()
+        plt.plot(sim_reg.time_points, sim_reg.window_ratio_send, label="AODV classique (t_send)")
+        plt.plot(sim_mod.time_points, sim_mod.window_ratio_send, label="AODV modifié (t_send)")
+        plt.xlabel("Temps")
+        plt.ylabel("Taux de délivrance (%)")
+        plt.title(f"Taux glissant basé sur t_send (fenêtre={W})")
+        plt.legend()
+        plt.show()
+
+if __name__ == "__main__" :
+    sim_conf = SimConfig(
+        nb_nodes=0,
+        area_size=800,
+        max_dist=250,
+        init_bat=100,
+        conso=(0.0082,0.00164,10),
+        dt=0.25,
+        ttl_max=7,
+        seuil_coeff=0.075,  # 750 / 10000
+        coeff_dist_weight=0.6,
+        coeff_bat_weight=0.4,
+        duration=100,
+    )
+
+    bm_conf = BonnMotionConfig(
+        bm_exe="C:\\Users\\millo\\Documents\\bonnmotion-3.0.1\\bin\\bm.bat",
+        out_dir="C:\\Users\\millo\\Documents\\GitHub\\TIPE\\bm_files\\",
+        vmin=10,
+        vmax=10,
+        pause=5
+    )
+    res = densite_parallel(sim_conf,bm_conf,5,2,15,15)
+    print(res)


### PR DESCRIPTION
### Motivation

- Remplacer la détection de rupture de lien basée sur `HELLO`/`RERR` par une validité temporelle des routes (dates d'expiration) pour retrouver le comportement des versions antérieures qui utilisaient des TTL/expiry sur les routes.
- Fournir une variante non intrusive dans de nouveaux fichiers afin de comparer l'approche `expiry` avec l'implémentation `hello` existante.

### Description

- Ajout de trois nouveaux modules `Codes/epure/node_expiry.py`, `Codes/epure/network_expiry.py` et `Codes/epure/simulation_expiry.py` qui reprennent la logique des `*_hello.py` mais basculent sur des expiry dates de route.
- Suppression de la gestion `HELLO`/`RERR` : le `Message` supporte désormais `RREQ`/`RREP`/`DATA` uniquement et le `Network` n'utilise plus le watchdog/loop HELLO ni la diffusion de `RERR`.
- Les routes stockent un timestamp d'expiration et sont renseignées par `update_route(..., expiry)` (utilisation de `cfg.ttl_max`), et `send_data`/`unicast_rrep`/`forward_data` vérifient cette expiry avant envoi, en supprimant la route expirée et en déclenchant un nouveau `RREQ` si nécessaire.
- `simulation_expiry.py` est câblé sur `network_expiry` et `node_expiry` pour permettre des comparaisons sans modifier les fichiers originaux.

### Testing

- Exécution de `python -m py_compile Codes/epure/node_expiry.py Codes/epure/network_expiry.py Codes/epure/simulation_expiry.py` et la compilation a réussi.
- Aucun test d'exécution de simulation complet automatisé n'a été lancé dans cette PR; seuls des contrôles de compilation ont été effectués avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d00413cc8320ac33dcc2cec1cd70)