### PR TITLE
Force pymoo optimizations to run with reg_aodv=False

### DIFF
--- a/Codes/epure/pymoo_opti.py
+++ b/Codes/epure/pymoo_opti.py
@@ -13,7 +13,6 @@ from pymoo.termination import get_termination
 
 from simulation_opti import (
     BonnMotionConfig,
-    ProtocolConfig,
     SimConfig,
     generate_bonnmotion_traces,
     run_comparison_simulations,
@@ -76,14 +75,11 @@ class AodvOptiProblem(Problem):
             d_min=p["d_min"],
             d_max=p["d_max"],
         )
-        protocol = ProtocolConfig(reg_aodv=False, max_duplicates=p["max_duplicates"], weight_seuil=p["weight_seuil"])
-
         res = run_comparison_simulations(
             config=config,
             nb_runs=self.nb_runs,
             seed_base=self.seed_base,
             trace_files=self.trace_files,
-            protocols=[protocol],
             use_parallel_runs=False,
             n_processes=self.n_processes,
         )

--- a/Codes/epure/simulation_opti.py
+++ b/Codes/epure/simulation_opti.py
@@ -220,13 +220,11 @@ def run_comparison_simulations(
     nb_runs: int,
     seed_base: int,
     trace_files: List[str],
-    protocols: List[ProtocolConfig] | None = None,
     use_parallel_runs: bool = True,
     n_processes: int | None = None,
 ):
     print(f"Simulations a {config.nb_nodes} noeuds débutées")
-    if protocols is None:
-        protocol = ProtocolConfig.from_mode(False)#, ProtocolConfig.from_mode(False)]
+    protocol = ProtocolConfig(reg_aodv=False, max_duplicates=2, weight_seuil=1.25)
     if n_processes is None:
         n_processes = max(1, cpu_count() - 1)
 


### PR DESCRIPTION
### Motivation
- The optimizer should evaluate only the modified protocol mode (i.e. `reg_aodv = False`) so simulations run by `pymoo_opti` match the intended optimization target. 

### Description
- `run_comparison_simulations` in `Codes/epure/simulation_opti.py` now always instantiates a fixed `ProtocolConfig(reg_aodv=False, max_duplicates=2, weight_seuil=1.25)` and the optional `protocols` parameter was removed.
- `Codes/epure/pymoo_opti.py` no longer creates or injects a `ProtocolConfig` per-evaluation and the now-unused `ProtocolConfig` import was removed.
- No defensive checks or alternate modes were added, keeping the functions minimal and specific to this constrained use case.

### Testing
- `python -m py_compile Codes/epure/simulation_opti.py Codes/epure/pymoo_opti.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cba459a48320a248dc19f57e1062)